### PR TITLE
03 classname buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ We need a Paginator.
 - The response of your api-backend or soruce must include the total elements, offset and limit.
 - Your Searcher must have a method that make the search.
 - In this method add two optional parameters: offset and limit.
+- To visualize styles default you must have bootstrap.
 
 ## Usage
 
@@ -66,6 +67,10 @@ render() {
           totalElements={this.state.totalElements}
           offset={this.state.offset}
           limit={this.state.limit}
+          buttonClassName={{
+            active: "btn btn-success",
+            default: "btn btn-warning",
+          }}
         >
 
           <YourSearcher/>
@@ -85,6 +90,7 @@ render() {
 |  offset (Required)| number  | the offset to calculate the current page |
 |  limit (Required)| number  |  Quantity of elements to show|
 |  searchMethod (Optional)| method |  Here link your Searcher's method. If you don't specify, the Goten's component take 'search' by default from your Searcher component|
+|  buttonClassName (Optional)| object |  this object has two styles properties **active** for selected page and **default** for the others buttons. |
 
 ## Contributions
 

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -9,3 +9,8 @@ if you add a new test
 
 npm run build
 npm test
+
+if you add a code in src
+
+npm run build
+npm start

--- a/example/public/index.html
+++ b/example/public/index.html
@@ -19,6 +19,8 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <title>React App</title>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goten-react-paginator",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "description": "GotenTextField is a react component that facilitates the fast use of paginator",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,12 @@ import React, { Component } from 'react';
 import { UltimatePagination } from './paginator'
 import PropTypes from 'prop-types';
 
+
+const buttonClassName = {
+    active: "btn btn-primary",
+    default: "btn btn-default"
+}
+
 export default class GotenPaginator extends Component {
     constructor(){
         super()
@@ -19,7 +25,7 @@ export default class GotenPaginator extends Component {
             <div>
                 {React.cloneElement(this.props.children[0],{ref: this.childRef})}
                 {this.props.children[1]}                                                            
-                <UltimatePagination onChange={(newPage) => this.changePage(newPage)} currentPage={this.props.offset/this.props.limit + (this.props.totalElements==0?  0 : 1)} 
+                <UltimatePagination className={props.buttonClassName || buttonClassName} onChange={(newPage) => this.changePage(newPage)} currentPage={this.props.offset/this.props.limit + (this.props.totalElements==0?  0 : 1)} 
                     totalPages={Math.ceil(this.props.totalElements/this.props.limit)}/>
             </div>
         )

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ export default class GotenPaginator extends Component {
             <div>
                 {React.cloneElement(this.props.children[0],{ref: this.childRef})}
                 {this.props.children[1]}                                                            
-                <UltimatePagination className={props.buttonClassName || buttonClassName} onChange={(newPage) => this.changePage(newPage)} currentPage={this.props.offset/this.props.limit + (this.props.totalElements==0?  0 : 1)} 
+                <UltimatePagination className={this.props.buttonClassName || buttonClassName} onChange={(newPage) => this.changePage(newPage)} currentPage={this.props.offset/this.props.limit + (this.props.totalElements==0?  0 : 1)} 
                     totalPages={Math.ceil(this.props.totalElements/this.props.limit)}/>
             </div>
         )

--- a/src/paginator.js
+++ b/src/paginator.js
@@ -1,38 +1,42 @@
 var React = require('react');
 var ReactUltimatePagination = require('react-ultimate-pagination');
- 
+
+
 function Page(props) {
   return (
     <button
       style={props.isActive ? {fontWeight: 'bold'} : null}
       onClick={props.onClick}
       disabled={props.disabled}
+      className={props.isActive ? props.buttonClassName.active : props.buttonClassName.default}
     >{props.value}</button>
   );
 }
  
 function Ellipsis(props) {
-  return <button onClick={props.onClick} disabled={props.disabled}>...</button>
+  return <button className={props.buttonClassName.default} onClick={props.onClick} disabled={props.disabled}>...</button>
 }
  
 function FirstPageLink(props) {
-  return <button onClick={props.onClick} disabled={props.disabled}>First</button>
+  return <button className={props.buttonClassName.default} onClick={props.onClick} disabled={props.disabled}>First</button>
 }
  
 function PreviousPageLink(props) {
-  return <button onClick={props.onClick} disabled={props.disabled}>Previous</button>
+  return <button className={props.buttonClassName.default} onClick={props.onClick} disabled={props.disabled}>Previous</button>
 }
  
 function NextPageLink(props) {
-  return <button onClick={props.onClick} disabled={props.disabled}>Next</button>
+  return <button className={props.buttonClassName.default} onClick={props.onClick} disabled={props.disabled}>Next</button>
 }
  
 function LastPageLink(props) {
-  return <button onClick={props.onClick} disabled={props.disabled}>Last</button>
+  return <button className={props.buttonClassName.default} onClick={props.onClick} disabled={props.disabled}>Last</button>
 }
  
 function Wrapper(props) {
-  return <div className="pagination">{props.children}</div>
+    const childrenWithProps = React.Children.map(props.children, child =>
+        React.cloneElement(child, {buttonClassName: props.className}));
+    return <div className="pagination">{childrenWithProps}</div>
 }
  
 var itemTypeToComponent = {


### PR DESCRIPTION
- Adds a prop "buttonClassName" that receives an object with two attributes, 'default' and 'active'. The first one is passed to all buttons except the one that is pressed (one of the number buttons), while 'active' is that specific one, to highlight it's pressed state.
 - It defaults to `{default: "btn btn-default", active: "btn btn-primary"}
- Currently doesn't support different classes for each button. It could be a nice improvement for more customization.
Closes #3 